### PR TITLE
fix: embed working URL for LLM Data Visualizer on /projects page

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -18,6 +18,20 @@ export default function ProjectsPage() {
           className="w-full border rounded-md shadow-sm"
         />
       </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">LLM Data Visualizer</h2>
+        <p className="text-muted-foreground text-base leading-relaxed">
+          Converts natural language into interactive D3.js charts using OpenAI and Tailwind CSS.
+        </p>
+        <iframe
+          loading="lazy"
+          src="https://ai-llm-data-visualizer-git-main-flavio-espinozas-projects.vercel.app"
+          width="100%"
+          height="500"
+          className="w-full border rounded-md shadow-sm"
+        />
+      </section>
     </main>
   )
 }


### PR DESCRIPTION
This PR updates the `/projects` page to correctly embed the deployed LLM Data Visualizer project.

### ✅ Changes included:
- Sets the iframe `src` to the verified Vercel domain:  
  `https://ai-llm-data-visualizer-git-main-flavio-espinozas-projects.vercel.app`
- Ensures the project preview loads successfully
- Maintains layout consistency with other embedded projects (e.g. AI Chat Assistant)

This closes the issue where the visualizer was not appearing due to a broken or missing deploy URL.
